### PR TITLE
Kd update remaining balance

### DIFF
--- a/client/js/components/payments/render-payments-owed.js
+++ b/client/js/components/payments/render-payments-owed.js
@@ -260,11 +260,11 @@ function renderPaymentsOwed(session) {
                         // console.log(payment.payments_id, status)
 
                         if(status.includes('PAID')) {
-                            selectListOwed.add(optionTwo, null);
                             selectListOwed.add(optionOne, null);
+                            selectListOwed.add(optionTwo, null);
                         } else {
-                            selectListOwed.add(optionOne, null);
                             selectListOwed.add(optionTwo, null);
+                            selectListOwed.add(optionOne, null);
                         }
 
                         row.appendChild(row_data_1);

--- a/controllers/payments/index.js
+++ b/controllers/payments/index.js
@@ -62,7 +62,6 @@ router.patch('/updateReceivedStatus/', (req, res) => {
                         completedPayments += 1;
                     }
                 });
-                console.log(updateBody.status)
                 if(completedPayments === response.rows.length || !updateBody.status) {
                     PaymentsEvent.updateCompletedStatus(response.rows[0].payment_event_id, updateBody.status).then(response => {
                         return response;

--- a/controllers/payments/index.js
+++ b/controllers/payments/index.js
@@ -62,8 +62,9 @@ router.patch('/updateReceivedStatus/', (req, res) => {
                         completedPayments += 1;
                     }
                 });
-                if(completedPayments === response.rows.length) {
-                    PaymentsEvent.updateCompletedStatus(response.rows[0].payment_event_id).then(response => {
+                console.log(updateBody.status)
+                if(completedPayments === response.rows.length || !updateBody.status) {
+                    PaymentsEvent.updateCompletedStatus(response.rows[0].payment_event_id, updateBody.status).then(response => {
                         return response;
                     });
                 }

--- a/models/payments.js
+++ b/models/payments.js
@@ -52,6 +52,13 @@ const Payments = {
             return response;
         });
     },
+    getPaymentByEventId: (event_id) => {
+        const query = 'SELECT * FROM payments WHERE payment_event_id = $1';
+        return db.query(query, [event_id]).then(response => {
+            return response;
+        })
+    },
+    
     create: (body) => {
         const query = `INSERT INTO payments (user_id,amount,percentage,paid_status,received_status,paid_date,payment_event_id) VALUES ($1,$2,$3,false,false,null,$4) RETURNING *`;
         return db

--- a/models/payments.js
+++ b/models/payments.js
@@ -46,11 +46,19 @@ const Payments = {
         });
     },
     updateReceivedStatus: ({ received_status, id }) => {
-        const query =
-            'UPDATE payments SET received_status = $1, paid_date = current_date WHERE id = $2 RETURNING *';
-        return db.query(query, [received_status, id]).then((response) => {
-            return response;
-        });
+        console.log(received_status)
+        if(received_status) {
+            const query =
+                'UPDATE payments SET received_status = $1, paid_date = current_date WHERE id = $2 RETURNING *';
+            return db.query(query, [received_status, id]).then((response) => {
+                return response;
+            });
+        } else {
+            const query = 'UPDATE payments SET received_status = $1, paid_date = null WHERE id = $2 RETURNING *';
+            return db.query(query, [received_status, id]).then((response) => {
+                return response;
+            });
+        }
     },
     getPaymentByEventId: (event_id) => {
         const query = 'SELECT * FROM payments WHERE payment_event_id = $1';

--- a/models/payments_event.js
+++ b/models/payments_event.js
@@ -33,12 +33,20 @@ const PaymentsEvent = {
             return response.rows;
         });
     },  
-    updateRemainingAmount: ({ payment_event_id, amount }) => {
-        const query = 'UPDATE payments_event SET remaining_amount = remaining_amount - $1 WHERE id = $2 RETURNING *';
-        // console.log(payment_event_id, amount)
-        return db.query(query, [amount, payment_event_id]).then((response) => {
-            return response.rows ? response.rows[0] : {};
-        });
+    updateRemainingAmount: ({ payment_event_id, amount, status }) => {
+        if(status) {
+            const query = 'UPDATE payments_event SET remaining_amount = remaining_amount - $1 WHERE id = $2 RETURNING *';
+            // console.log(payment_event_id, amount)
+            return db.query(query, [amount, payment_event_id]).then((response) => {
+                return response.rows ? response.rows[0] : {};
+            });
+        } else {
+            const query = 'UPDATE payments_event SET remaining_amount = remaining_amount + $1 WHERE id = $2 RETURNING *';
+            // console.log(payment_event_id, amount)
+            return db.query(query, [amount, payment_event_id]).then((response) => {
+                return response.rows ? response.rows[0] : {};
+            });   
+        }
     },
     updateCompletedStatus: (event_id) => {
         const query = 'UPDATE payments_event SET completed = true WHERE id = $1 RETURNING *';

--- a/models/payments_event.js
+++ b/models/payments_event.js
@@ -48,11 +48,18 @@ const PaymentsEvent = {
             });   
         }
     },
-    updateCompletedStatus: (event_id) => {
-        const query = 'UPDATE payments_event SET completed = true WHERE id = $1 RETURNING *';
-        return db.query(query, [event_id]).then(response => {
-            return response.rows ? response.rows[0] : {};;
-        })
+    updateCompletedStatus: (event_id, status) => {
+        if(status) {
+            const query = 'UPDATE payments_event SET completed = true WHERE id = $1 RETURNING *';
+            return db.query(query, [event_id]).then(response => {
+                return response.rows ? response.rows[0] : {};
+            })
+        } else {
+            const query = 'UPDATE payments_event SET completed = false WHERE id = $1 RETURNING *';
+            return db.query(query, [event_id]).then(response => {
+                return response.rows ? response.rows[0] : {};
+            })
+        }
     },
     create: (body) => {
         const query = `INSERT INTO payments_event (event_name, total_amount, event_creator_id, description, creation_date, due_date, remaining_amount, completed) VALUES ($1, $2, $3, $4, $5, $6, $7, false) RETURNING *`;

--- a/models/payments_event.js
+++ b/models/payments_event.js
@@ -35,10 +35,16 @@ const PaymentsEvent = {
     },  
     updateRemainingAmount: ({ payment_event_id, amount }) => {
         const query = 'UPDATE payments_event SET remaining_amount = remaining_amount - $1 WHERE id = $2 RETURNING *';
-        console.log(payment_event_id, amount)
+        // console.log(payment_event_id, amount)
         return db.query(query, [amount, payment_event_id]).then((response) => {
             return response.rows ? response.rows[0] : {};
         });
+    },
+    updateCompletedStatus: (event_id) => {
+        const query = 'UPDATE payments_event SET completed = true WHERE id = $1 RETURNING *';
+        return db.query(query, [event_id]).then(response => {
+            return response.rows ? response.rows[0] : {};;
+        })
     },
     create: (body) => {
         const query = `INSERT INTO payments_event (event_name, total_amount, event_creator_id, description, creation_date, due_date, remaining_amount, completed) VALUES ($1, $2, $3, $4, $5, $6, $7, false) RETURNING *`;


### PR DESCRIPTION
- Add initial logic to decrement remaining about from the payments_event table when the user is moving received status to paid (removing potential for decrement of remaining amount when moving back to unpaid status)
- Add completed functionality so that when all payments are marked as paid, it is updates status as paid
- Update logic to allow for the user to 'undo' their paid status update and reverse updates to the DB (specifically remaining amount and completed in the payment_events table)
- Update logic to 'undo' paid_date from payments table if the user reverses the paid status